### PR TITLE
Adding a basic self-host guide

### DIFF
--- a/guides/self-host.md
+++ b/guides/self-host.md
@@ -1,0 +1,14 @@
+---
+title: How to self-host Padloc
+icon: cloud-slash
+description: A list of links for simple guides on how to self-host Padloc.
+---
+
+With the release of Padloc 4 it's even easier to self-host your own server and
+apps, so you don't even have to trust us!
+
+You can see
+[some up-to-date guides using Docker here](https://github.com/padloc/padloc/tree/main/docs/examples/hosting/docker).
+
+If you have any questions, please don't hesitate to contact us at
+[support@padloc.app](mailto:support@padloc.app)!


### PR DESCRIPTION
Right now only linking to the Docker code examples. This solves the 404 problem of old indexed links.